### PR TITLE
Fixed Security Exception

### DIFF
--- a/OpenUDID_manager.java
+++ b/OpenUDID_manager.java
@@ -104,8 +104,13 @@ public class OpenUDID_manager implements ServiceConnection{
 			final ServiceInfo servInfo = mMatchingIntents.get(0).serviceInfo;
             final Intent i = new Intent();
             i.setComponent(new ComponentName(servInfo.applicationInfo.packageName, servInfo.name));
-            mContext.bindService(i, this,  Context.BIND_AUTO_CREATE);
             mMatchingIntents.remove(0);
+            try	{	// try added by Lionscribe
+            	mContext.bindService(i, this,  Context.BIND_AUTO_CREATE);
+            }
+            catch (SecurityException e) {
+                startService();	// ignore this one, and start next one
+            }
 		} else { //No more service to test
 			
 			getMostFrequentOpenUDID(); //Choose the most frequent


### PR DESCRIPTION
Added try-catch to tbindService so that it ignores SecurityExceptions thrown by startService on some newer Samsung devices. I have posted this fix on https://github.com/Countly/countly-sdk-android/issues/9
